### PR TITLE
Added support for multiple StatsD exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Support for multiple StatsD exporters
+- `distribution` and `gauge` method in `StatsdLogger`
 ### Changed
 - Expected configuration for StatsD in Django settings
 - Moved custom exception `DjangoStatsdConfigurationMissingException` to a separate module
+- Replaced all static methods in `StatsdLogger` with instance methods to support multiple exporters
+
 ### Breaking Changes
 - Expected configuration for StatsD exporter has been changed to support multiple exporters. So config varaibles in Django settings:`STATSD_HOST`, `STATSD_PORT`, `STATSD_SERVICE_NAME`, `STATSD_PREFIX` are now deprecated. The new configuration is expected to be present in `STATSD_EXPORTERS`. For the latest configuration guide check [README.md](README.md) or the doc-string in [django_statsd.client](django_statsd/client.py) module.
+- All the static methods in `StatsdLogger` have been replaced with instance methods which means it cannot be used unless instantiated.
 - Custom exception `DjangoStatsdConfigurationMissingException` has been moved to a separate module [django_statsd.exception](django_statsd/exception.py) and so any existing imports will need to be updated accordingly.
 
 ## 0.3.0 (2022-08-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Expected configuration for StatsD in Django settings
 - Moved custom exception `DjangoStatsdConfigurationMissingException` to a separate module
 ### Breaking Changes
-- Expected configuration for StatsD exporter has been changed to support multiple exporters. So config varaibles in Django settings:`STATSD_HOST`, `STATSD_PORT`, `STATSD_SERVICE_NAME`, `STATSD_PREFIX` are now deprecated. The new configuration is expected to be present in `STATSD_EXPORTERS`. For the latest configuration parameters check the doc-string in `django_statsd.client` module.
-- Custom exception `DjangoStatsdConfigurationMissingException` has been moved to a separate module `django_statsd.exception` and so any existing imports will need to be updated accordingly.
+- Expected configuration for StatsD exporter has been changed to support multiple exporters. So config varaibles in Django settings:`STATSD_HOST`, `STATSD_PORT`, `STATSD_SERVICE_NAME`, `STATSD_PREFIX` are now deprecated. The new configuration is expected to be present in `STATSD_EXPORTERS`. For the latest configuration guide check [README.md](README.md) or the doc-string in [django_statsd.client](django_statsd/client.py) module.
+- Custom exception `DjangoStatsdConfigurationMissingException` has been moved to a separate module [django_statsd.exception](django_statsd/exception.py) and so any existing imports will need to be updated accordingly.
 
 ## 0.3.0 (2022-08-04)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+### Added
+- Support for multiple StatsD exporters
+### Changed
+- Expected configuration for StatsD in Django settings
+- Moved custom exception `DjangoStatsdConfigurationMissingException` to a separate module
+### Breaking Changes
+- Expected configuration for StatsD exporter has been changed to support multiple exporters. So config varaibles in Django settings:`STATSD_HOST`, `STATSD_PORT`, `STATSD_SERVICE_NAME`, `STATSD_PREFIX` are now deprecated. The new configuration is expected to be present in `STATSD_EXPORTERS`. For the latest configuration parameters check the doc-string in `django_statsd.client` module.
+- Custom exception `DjangoStatsdConfigurationMissingException` has been moved to a separate module `django_statsd.exception` and so any existing imports will need to be updated accordingly.
 
 ## 0.3.0 (2022-08-04)
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,13 +20,26 @@ To configure django-statsd, you need to add below configuration to django settin
 
 ```
 # settings.py
-STATSD_HOST = '127.0.0.1'               # required
-STATSD_PORT = 8045                      # required
-STATSD_SERVICE_NAME = 'service_name'    # optional - adds a dimension to all your metrics
-STATSD_PREFIX = ''                      # optional - adds prefix to all metrics
 STATSD_IGNORED_IPS = ['127.0.0.1']      # optional - ignore metrics from requests from listed ips
 STATSD_REQUEST_META_IP_PRECEDENCE_ORDER = ('HTTP_X_ORIGINAL_FORWARDED_FOR', 'REMOTE_ADDR') # optional - default request meta precedence order for ip address
 
+# required | `HOST` and `PORT` must be configured for `default` exporter. Additional exporters are optional, but if configured `HOST` and `PORT` must be specified.
+STATSD_EXPORTERS = {
+    # default exporter | required
+    'default': {
+        'HOST': 'localhost',                # required
+        'PORT': '9125',                     # required
+        'SERVICE_NAME': 'service-name',     # optional - adds a dimension to all your metrics
+        'PREFIX': 'service_prefix'          # optional - adds prefix to all metrics
+    },
+    # secondary exporter | optional
+    'exporter_1': {
+        'HOST': 'statsd.host',
+        'PORT': '9125',
+        'SERVICE_NAME': 'service-name',
+        'PREFIX': 'service-prefix'
+    },
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # django-statsd-prom-exporter
 
-A collection of django middleware to track django + WSGI service metrics accurately via [prom/statsd-exporter](https://github.com/prometheus/statsd_exporter) sidecar + [prometheus](https://prometheus.io/)
+A collection of django middleware to track django + WSGI service metrics accurately via [prom/statsd-exporter](https://github.com/prometheus/statsd_exporter) (as sidecar / dedicated-instance) + [prometheus](https://prometheus.io/)
 
 ## Features
 * StatsdCountMetricMiddleware - Request Count & Request Exception Count metrics
 * StatsdLatencyMetricMiddleware - Request Latency metrics
-* StatsdLogger - Log a custom count metric
+* StatsdLogger - Log a custom metric
 
 
 ## Installation
@@ -18,7 +18,7 @@ pip install -U django-statsd-prom-exporter
 
 To configure django-statsd, you need to add below configuration to django settings
 
-```
+```python
 # settings.py
 STATSD_IGNORED_IPS = ['127.0.0.1']      # optional - ignore metrics from requests from listed ips
 STATSD_REQUEST_META_IP_PRECEDENCE_ORDER = ('HTTP_X_ORIGINAL_FORWARDED_FOR', 'REMOTE_ADDR') # optional - default request meta precedence order for ip address
@@ -51,16 +51,33 @@ Add the following to your `settings.py`
 2. Add `django_statsd.middleware.StatsdLatencyMetricMiddleware` to the top of your `MIDDLEWARE` to get latency metrics
 
 ### Logger
-Used to track occurrence of a specific event
-```
+Used to track custom metrics
+```python
 from django_statsd.logger import StatsdLogger
 
+logger = StatsdLogger("exporter_1")
+
 # some process ran with error
-StatsdLogger.incr('process_a_error')
+logger.incr('process_a_error')
+
 # process error resolved
-StatsdLogger.decr('process_a_error')
+logger.decr('process_a_error')
+
+# log time taken to process a task in buckets (50PC, 90PC, 99PC)
+logger.histogram('task_identifier', 1.2)
 ```
 
+Default exporter can also be used in the folloing way :
+```python
+from django_statsd.logger import statsd_default_logger as statsd_logger
+
+# some process ran with error
+statsd_logger.incr('process_a_error')
+
+# This is equivalent to...
+from django_statsd.logger import StatsdLogger
+statsd_logger = StatsdLogger("default")
+```
 
 ## Build the package
 
@@ -70,12 +87,12 @@ StatsdLogger.decr('process_a_error')
 
 ### Initialise Build Environment
 One time initialisation
-```
+```bash
 make init
 ```
 
 ### Build and install locally
-```
+```bash
 make dist
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ logger.incr('process_a_error')
 logger.decr('process_a_error')
 
 # log time taken to process a task in buckets (50PC, 90PC, 99PC)
-logger.histogram('task_identifier', 1.2)
+logger.distribition('task_identifier', 1.2)
 ```
 
 Default exporter can also be used in the folloing way :

--- a/django_statsd/__init__.py
+++ b/django_statsd/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for django-statsd-prom-exporter-middleware."""
 
 __author__ = """Kshitij Nagvekar"""
-__email__ = 'kshitij.nagvekar@workindia.in'
-__version__ = '0.3.0'
+__email__ = "kshitij.nagvekar@workindia.in"
+__version__ = "0.3.0"

--- a/django_statsd/client.py
+++ b/django_statsd/client.py
@@ -47,8 +47,8 @@ def get_client(exporter_alias: str = 'default'):
 
     host = exporter_config.get('HOST')
     port = exporter_config.get('PORT')
-    service_name = exporter_config.get('STATSD_SERVICE_NAME')
-    prefix = exporter_config.get('STATSD_PREFIX', None)
+    service_name = exporter_config.get('SERVICE_NAME')
+    prefix = exporter_config.get('PREFIX', None)
 
     if not (host and port):
         raise DjangoStatsdConfigurationMissingException(exporter_alias)

--- a/django_statsd/client.py
+++ b/django_statsd/client.py
@@ -54,7 +54,7 @@ def get_client(exporter_alias: str = 'default'):
     service_name = exporter_config.get('STATSD_SERVICE_NAME')
     prefix = exporter_config.get('STATSD_PREFIX', None)
 
-    if not host or not port:
+    if not (host and port):
         raise DjangoStatsdConfigurationMissingException(exporter_alias)
 
     constant_tags = []

--- a/django_statsd/client.py
+++ b/django_statsd/client.py
@@ -3,26 +3,22 @@ from datadog import DogStatsd
 from django_statsd.exception import DjangoStatsdConfigurationMissingException
 
 """
-# StatsD configuration for Django settings
+# StatsD configuration in Django settings
 # ----------------------------------------
-STATSD_IGNORED_IPS = []
-STATSD_REQUEST_META_IP_PRECEDENCE_ORDER = (
-    'HTTP_X_ORIGINAL_FORWARDED_FOR',
-    'X_FORWARDED_FOR',
-    'HTTP_X_FORWARDED_FOR',
-    'HTTP_X_FORWARDED',
-    'HTTP_FORWARDED_FOR',
-    'REMOTE_ADDR'
-)
+
+STATSD_IGNORED_IPS = ['127.0.0.1']      # optional - ignore metrics from requests from listed ips
+STATSD_REQUEST_META_IP_PRECEDENCE_ORDER = ('HTTP_X_ORIGINAL_FORWARDED_FOR', 'REMOTE_ADDR') # optional - default request meta precedence order for ip address
+
+# required | `HOST` and `PORT` must be configured for `default` exporter. Additional exporters are optional, but if configured `HOST` and `PORT` must be specified.
 STATSD_EXPORTERS = {
-    # Default Exporter
+    # default exporter | required
     'default': {
-        'HOST': 'localhost',
-        'PORT': '9125',
-        'SERVICE_NAME': 'service-name',
-        'PREFIX': 'service_prefix'
+        'HOST': 'localhost',                # required
+        'PORT': '9125',                     # required
+        'SERVICE_NAME': 'service-name',     # optional - adds a dimension to all your metrics
+        'PREFIX': 'service_prefix'          # optional - adds prefix to all metrics
     },
-    # Secondary Exporter
+    # secondary exporter | optional
     'exporter_1': {
         'HOST': 'statsd.host',
         'PORT': '9125',

--- a/django_statsd/client.py
+++ b/django_statsd/client.py
@@ -38,17 +38,17 @@ def _get(key, default=None):
     return getattr(settings, key, default)
 
 
-def get_client(exporter_alias: str = 'default'):
+def get_client(exporter_alias: str = "default"):
     if exporter_alias in _clients:
         return _clients[exporter_alias]
 
-    statsd_exporters: dict = _get('STATSD_EXPORTERS', {})
+    statsd_exporters: dict = _get("STATSD_EXPORTERS", {})
     exporter_config = statsd_exporters.get(exporter_alias, {})
 
-    host = exporter_config.get('HOST')
-    port = exporter_config.get('PORT')
-    service_name = exporter_config.get('SERVICE_NAME')
-    prefix = exporter_config.get('PREFIX', None)
+    host = exporter_config.get("HOST")
+    port = exporter_config.get("PORT")
+    service_name = exporter_config.get("SERVICE_NAME")
+    prefix = exporter_config.get("PREFIX", None)
 
     if not (host and port):
         raise DjangoStatsdConfigurationMissingException(exporter_alias)
@@ -56,28 +56,33 @@ def get_client(exporter_alias: str = 'default'):
     constant_tags = []
 
     if service_name:
-        constant_tags.append(f'service:{service_name}')
+        constant_tags.append(f"service:{service_name}")
 
-    client = DogStatsd(host=host, port=port, namespace=prefix, constant_tags=constant_tags)
+    client = DogStatsd(
+        host=host, port=port, namespace=prefix, constant_tags=constant_tags
+    )
     _clients[exporter_alias] = client
     return client
 
 
 if not _default_client:
-    _default_client = get_client('default')
+    _default_client = get_client("default")
 
 if _ignored_ips is None:
-    _ignored_ips = _get('STATSD_IGNORED_IPS', [])
+    _ignored_ips = _get("STATSD_IGNORED_IPS", [])
 
 if _request_meta_ip_precedence_order is None:
-    _request_meta_ip_precedence_order = _get('STATSD_REQUEST_META_IP_PRECEDENCE_ORDER', (
-        'HTTP_X_ORIGINAL_FORWARDED_FOR',
-        'X_FORWARDED_FOR',
-        'HTTP_X_FORWARDED_FOR',
-        'HTTP_X_FORWARDED',
-        'HTTP_FORWARDED_FOR',
-        'REMOTE_ADDR'
-    ))
+    _request_meta_ip_precedence_order = _get(
+        "STATSD_REQUEST_META_IP_PRECEDENCE_ORDER",
+        (
+            "HTTP_X_ORIGINAL_FORWARDED_FOR",
+            "X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_FORWARDED_FOR",
+            "REMOTE_ADDR",
+        ),
+    )
 
 client = _default_client
 IGNORED_IPS = _ignored_ips

--- a/django_statsd/client.py
+++ b/django_statsd/client.py
@@ -1,41 +1,74 @@
 from django.conf import settings
 from datadog import DogStatsd
+from django_statsd.exception import DjangoStatsdConfigurationMissingException
 
-_client = None
+"""
+# StatsD configuration for Django settings
+# ----------------------------------------
+STATSD_IGNORED_IPS = []
+STATSD_REQUEST_META_IP_PRECEDENCE_ORDER = (
+    'HTTP_X_ORIGINAL_FORWARDED_FOR',
+    'X_FORWARDED_FOR',
+    'HTTP_X_FORWARDED_FOR',
+    'HTTP_X_FORWARDED',
+    'HTTP_FORWARDED_FOR',
+    'REMOTE_ADDR'
+)
+STATSD_EXPORTERS = {
+    # Default Exporter
+    'default': {
+        'HOST': 'localhost',
+        'PORT': '9125',
+        'SERVICE_NAME': 'service-name',
+        'PREFIX': 'service_prefix'
+    },
+    # Secondary Exporter
+    'exporter_1': {
+        'HOST': 'statsd.host',
+        'PORT': '9125',
+        'SERVICE_NAME': 'service-name',
+        'PREFIX': 'service-prefix'
+    },
+}
+"""
+
+_clients = dict()
+_default_client = None
 _ignored_ips = None
 _request_meta_ip_precedence_order = None
-
-
-class DjangoStatsdConfigurationMissingException(Exception):
-
-    def __str__(self):
-        return 'STATSD_HOST, STATSD_PORT configuration is missing in django settings. ' \
-               'Django-Statsd cannot work without these settings.'
 
 
 def _get(key, default=None):
     return getattr(settings, key, default)
 
 
-def get_client():
-    host = _get('STATSD_HOST')
-    port = _get('STATSD_PORT')
-    service_name = _get('STATSD_SERVICE_NAME')
-    prefix = _get('STATSD_PREFIX', None)
+def get_client(exporter_alias: str = 'default'):
+    if exporter_alias in _clients:
+        return _clients[exporter_alias]
+
+    statsd_exporters: dict = _get('STATSD_EXPORTERS', {})
+    exporter_config = statsd_exporters.get(exporter_alias, {})
+
+    host = exporter_config.get('HOST')
+    port = exporter_config.get('PORT')
+    service_name = exporter_config.get('STATSD_SERVICE_NAME')
+    prefix = exporter_config.get('STATSD_PREFIX', None)
 
     if not host or not port:
-        raise DjangoStatsdConfigurationMissingException()
+        raise DjangoStatsdConfigurationMissingException(exporter_alias)
 
     constant_tags = []
 
     if service_name:
         constant_tags.append(f'service:{service_name}')
 
-    return DogStatsd(host=host, port=port, namespace=prefix, constant_tags=constant_tags)
+    client = DogStatsd(host=host, port=port, namespace=prefix, constant_tags=constant_tags)
+    _clients[exporter_alias] = client
+    return client
 
 
-if not _client:
-    _client = get_client()
+if not _default_client:
+    _default_client = get_client('default')
 
 if _ignored_ips is None:
     _ignored_ips = _get('STATSD_IGNORED_IPS', [])
@@ -50,6 +83,6 @@ if _request_meta_ip_precedence_order is None:
         'REMOTE_ADDR'
     ))
 
-client = _client
+client = _default_client
 IGNORED_IPS = _ignored_ips
 REQUEST_META_IP_PRECEDENCE_ORDER = _request_meta_ip_precedence_order

--- a/django_statsd/exception.py
+++ b/django_statsd/exception.py
@@ -5,6 +5,6 @@ class DjangoStatsdConfigurationMissingException(Exception):
 
     def __str__(self):
         return (
-            f'HOST, PORT configuration is missing for exporter_alias: {self.exporter_alias} in django settings.'
-            ' Django-Statsd cannot work without these settings.'
+            f"HOST, PORT configuration is missing for exporter_alias: {self.exporter_alias} in django settings."
+            " Django-Statsd cannot work without these settings."
         )

--- a/django_statsd/exception.py
+++ b/django_statsd/exception.py
@@ -1,0 +1,10 @@
+class DjangoStatsdConfigurationMissingException(Exception):
+    def __init__(self, exporter_alias: str, *args: object) -> None:
+        self.exporter_alias = exporter_alias
+        super().__init__(*args)
+
+    def __str__(self):
+        return (
+            f'HOST, PORT configuration is missing for exporter_alias: {self.exporter_alias} in django settings.'
+            ' Django-Statsd cannot work without these settings.'
+        )

--- a/django_statsd/logger.py
+++ b/django_statsd/logger.py
@@ -1,14 +1,70 @@
-from django_statsd.client import client
+from typing import List, Optional
+from django_statsd.client import get_client
 
-DJANGO_STATSD_METRIC_COUNT = "django_statsd_metric_count_{}"
+DJANGO_STATSD_METRIC_COUNT = "django_statsd_{}_total"
+DJANGO_STATSD_METRIC_HISTOGRAM = "django_statsd_{}_bucket"
+DJANGO_STATSD_METRIC_GAUGE = "django_statsd_{}"
 
 
 class StatsdLogger:
+    def __init__(self, exporter_alias: str) -> None:
+        self._exporter_alias = exporter_alias
+        self._client = get_client(exporter_alias)
 
-    @staticmethod
-    def incr(metric_name):
-        client.increment(DJANGO_STATSD_METRIC_COUNT.format(metric_name))
+    def incr(
+        self,
+        metric_name: str,
+        value: float = 1,
+        tags: Optional[List[str]] = None,
+        sample_rate: Optional[float] = None,
+    ):
+        self._client.increment(
+            DJANGO_STATSD_METRIC_COUNT.format(metric_name),
+            value,
+            tags,
+            sample_rate,
+        )
 
-    @staticmethod
-    def decr(metric_name):
-        client.decrement(DJANGO_STATSD_METRIC_COUNT.format(metric_name))
+    def decr(
+        self,
+        metric_name: str,
+        value: float = 1,
+        tags: Optional[List[str]] = None,
+        sample_rate: Optional[float] = None,
+    ):
+        self._client.decrement(
+            DJANGO_STATSD_METRIC_COUNT.format(metric_name),
+            value,
+            tags,
+            sample_rate,
+        )
+
+    def distribition(
+        self,
+        metric_name: str,
+        value: float,
+        tags: Optional[List[str]] = None,
+        sample_rate: Optional[float] = None,
+    ):
+        self._client.distribution(
+            DJANGO_STATSD_METRIC_HISTOGRAM.format(metric_name),
+            value,
+            tags,
+            sample_rate,
+        )
+
+    def gauge(
+        self,
+        metric_name: str,
+        value: float,
+        tags: Optional[List[str]] = None,
+        sample_rate: Optional[float] = None,
+    ):
+        self._client.gauge(
+            DJANGO_STATSD_METRIC_GAUGE.format(metric_name),
+            value,
+            tags,
+            sample_rate,
+        )
+
+statsd_default_logger = StatsdLogger(exporter_alias="default")

--- a/django_statsd/logger.py
+++ b/django_statsd/logger.py
@@ -67,4 +67,5 @@ class StatsdLogger:
             sample_rate,
         )
 
+
 statsd_default_logger = StatsdLogger(exporter_alias="default")

--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -16,16 +16,16 @@ if DJANGO_VERSION >= (1, 10, 0):
 else:
     MiddlewareMixin = object
 
-REQUEST_LATENCY_METRIC_NAME = 'django_request_latency_seconds'
-REQUEST_COUNT_METRIC_NAME = 'django_request_count'
-REQUEST_EXCEPTION_COUNT_METRIC_NAME = 'django_request_exception_count'
+REQUEST_LATENCY_METRIC_NAME = "django_request_latency_seconds"
+REQUEST_COUNT_METRIC_NAME = "django_request_count"
+REQUEST_EXCEPTION_COUNT_METRIC_NAME = "django_request_exception_count"
 
 
 def _get_url_name(request: HttpRequest):
     try:
         return resolve(request.path_info).url_name
     except Resolver404:
-        return 'resolve_not_found'
+        return "resolve_not_found"
 
 
 def _get_request_ip(request: HttpRequest):
@@ -33,7 +33,7 @@ def _get_request_ip(request: HttpRequest):
         header_value = request.META.get(header)
 
         if header_value:
-            return header_value.split(',')[0].strip()
+            return header_value.split(",")[0].strip()
 
 
 def _is_ip_ignored_in_metrics(request: HttpRequest):
@@ -41,39 +41,47 @@ def _is_ip_ignored_in_metrics(request: HttpRequest):
 
 
 class StatsdCountMetricMiddleware(MiddlewareMixin):
-
     def process_response(self, request: HttpRequest, response: HttpResponse):
         if not _is_ip_ignored_in_metrics(request):
-            client.increment(REQUEST_COUNT_METRIC_NAME, tags=[
-                f'method:{request.method}',
-                f'endpoint:{_get_url_name(request)}',
-                f'status:{response.status_code}'
-            ])
+            client.increment(
+                REQUEST_COUNT_METRIC_NAME,
+                tags=[
+                    f"method:{request.method}",
+                    f"endpoint:{_get_url_name(request)}",
+                    f"status:{response.status_code}",
+                ],
+            )
 
         return response
 
     def process_exception(self, request: HttpRequest, exception: HttpResponse):
         if not _is_ip_ignored_in_metrics(request):
-            client.increment(REQUEST_EXCEPTION_COUNT_METRIC_NAME, tags=[
-                f'method:{request.method}',
-                f'endpoint:{_get_url_name(request)}',
-                f'exception:{exception.__class__.__name__}'
-            ])
+            client.increment(
+                REQUEST_EXCEPTION_COUNT_METRIC_NAME,
+                tags=[
+                    f"method:{request.method}",
+                    f"endpoint:{_get_url_name(request)}",
+                    f"exception:{exception.__class__.__name__}",
+                ],
+            )
 
 
 class StatsdLatencyMetricMiddleware(MiddlewareMixin):
-
     def process_request(self, request: HttpRequest):
         request._start_time = time.time()
 
     def process_response(self, request: HttpRequest, response: HttpResponse):
         if not _is_ip_ignored_in_metrics(request):
-            if hasattr(request, '_start_time'):
+            if hasattr(request, "_start_time"):
                 _response_time_ms = int((time.time() - request._start_time) * 1000)
-                client.histogram(REQUEST_LATENCY_METRIC_NAME, _response_time_ms, tags=[
-                    f'method:{request.method}',
-                    f'endpoint:{_get_url_name(request)}',
-                    f'status:{response.status_code}'
-                ])
+                client.histogram(
+                    REQUEST_LATENCY_METRIC_NAME,
+                    _response_time_ms,
+                    tags=[
+                        f"method:{request.method}",
+                        f"endpoint:{_get_url_name(request)}",
+                        f"status:{response.status_code}",
+                    ],
+                )
 
         return response

--- a/setup.py
+++ b/setup.py
@@ -9,43 +9,32 @@ from setuptools import setup
 def read(filename):
     filename = os.path.join(os.path.dirname(__file__), filename)
     text_type = type(u"")
-    with io.open(filename, mode="r", encoding='utf-8') as fd:
-        return re.sub(text_type(r':[a-z]+:`~?(.*?)`'), text_type(r'``\1``'), fd.read())
+    with io.open(filename, mode="r", encoding="utf-8") as fd:
+        return re.sub(text_type(r":[a-z]+:`~?(.*?)`"), text_type(r"``\1``"), fd.read())
 
 
 setup(
     name="django-statsd-prom-exporter",
-    version='0.3.0',
+    version="0.3.0",
     url="https://github.com/workindia/django-statsd-prom-exporter",
     license="MIT license",
-
     author="Kshitij Nagvekar",
     author_email="kshitij.nagvekar@workindia.in",
-
     description="A collection of django middleware to track django + WSGI service metrics accurately via "
-                "prom/statsd-exporter sidecar + prometheus",
+    "prom/statsd-exporter sidecar + prometheus",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-
-    packages=find_packages(exclude=('tests',)),
-
-    install_requires=[
-        'django',
-        'datadog >= 0.42.0'
-    ],
-    setup_requires=[
-        'wheel',
-        'pip>=20'
-    ],
-    python_requires='>=3.6',
-
+    packages=find_packages(exclude=("tests",)),
+    install_requires=["django", "datadog >= 0.42.0"],
+    setup_requires=["wheel", "pip>=20"],
+    python_requires=">=3.6",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        "Operating System :: OS Independent"
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Operating System :: OS Independent",
     ],
 )


### PR DESCRIPTION
I have added support for multiple exporters. The idea is that the user will have the choice for what exporter to use depending on the use case. In my use case, I want to use StatsD as a sidecar for API pods and a dedicated StatsD instance for all the Kafka-consumer metrics

Changes:
- Modified expected configuration to add support for multiple exporters
- Moved custom exception to separate module